### PR TITLE
Template Incorrectly pulling in Variable

### DIFF
--- a/ft-kafka_proxy/templates/supervisord.conf.erb
+++ b/ft-kafka_proxy/templates/supervisord.conf.erb
@@ -5,7 +5,7 @@ file=/var/run/supervisor.sock
 port=9001
 
 [supervisord]
-logfile=<%=supervisord_log_dir%>/supervisord.log
+logfile=<%= @supervisord_log_dir %>/supervisord.log
 logfile_maxbytes=5MB
 logfile_backups=30
 loglevel=info
@@ -20,8 +20,8 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 [supervisorctl]
 serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 
-[program:<%=kafka_proxy%>]
-command=<%=start_script%>
+[program:<%= @kafka_proxy %>]
+command=<%= @start_script %>
 autorestart=true
 stopasgroup=true
 killasgroup=true

--- a/ft-kafka_proxy/templates/supervisord.init.erb
+++ b/ft-kafka_proxy/templates/supervisord.init.erb
@@ -39,7 +39,7 @@ SUPERVISORCTL=$PREFIX/bin/supervisorctl
 PIDFILE=/var/run/supervisord.pid
 LOCKFILE=/var/lock/subsys/supervisord
 
-OPTIONS="--configuration <%=supervisord_config_file%>"
+OPTIONS="--configuration <%= @supervisord_config_file %>"
 
 # unset this variable if you don't care to wait for child processes to shutdown before removing the $LOCKFILE-lock
 WAIT_FOR_SUBPROCESSES=yes


### PR DESCRIPTION
Puppet 3 will complain about the deprecated way the variable is called

 Variable access via 'supervisord_config_file' is deprecated. Use '@supervisord_config_file' instead. template 